### PR TITLE
chore(package): Update node engine

### DIFF
--- a/dist/components/BlocksRangeInput/BlocksRangeInput.d.ts
+++ b/dist/components/BlocksRangeInput/BlocksRangeInput.d.ts
@@ -1,6 +1,5 @@
 import { default as React } from 'react';
 import { BlocksRangeInputOptions } from './types';
-
 export interface BlocksRangeInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     options: BlocksRangeInputOptions;
 }

--- a/dist/components/BlocksRangeInput/blocksRangeHelpers.d.ts
+++ b/dist/components/BlocksRangeInput/blocksRangeHelpers.d.ts
@@ -1,5 +1,4 @@
 import { ManipulatorEventType } from '../types';
 import { BlocksRangeInputOptions } from './types';
-
 export declare const formatBlocksRange: (value: string, options: BlocksRangeInputOptions, addTrailingSeparator?: boolean) => string;
 export declare const checkShouldAddTrailingSeparator: (value: string, options: BlocksRangeInputOptions, eventType: ManipulatorEventType, didAdd: boolean, isAtLastPosition: boolean) => boolean;

--- a/dist/components/BlocksRangeInput/index.d.ts
+++ b/dist/components/BlocksRangeInput/index.d.ts
@@ -1,4 +1,3 @@
 import { default as BlocksRangeInput, BlocksRangeInputProps } from './BlocksRangeInput';
-
 export default BlocksRangeInput;
 export type { BlocksRangeInputProps };

--- a/dist/components/NumberInput/NumberInput.d.ts
+++ b/dist/components/NumberInput/NumberInput.d.ts
@@ -1,6 +1,5 @@
 import { default as React } from 'react';
 import { NumberInputOptions } from './types';
-
 export interface NumberInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     options: NumberInputOptions;
 }

--- a/dist/components/NumberInput/index.d.ts
+++ b/dist/components/NumberInput/index.d.ts
@@ -1,4 +1,3 @@
 import { default as NumberInput, NumberInputProps } from './NumberInput';
-
 export default NumberInput;
 export type { NumberInputProps };

--- a/dist/components/NumberInput/numberHelpers.d.ts
+++ b/dist/components/NumberInput/numberHelpers.d.ts
@@ -1,5 +1,4 @@
 import { ManipulatorEventType } from '../types';
 import { NumberInputOptions } from './types';
-
 export declare const formatNumber: (value: string, options: NumberInputOptions, event: ManipulatorEventType) => string;
 export declare const checkDidRemoveDecimalDelimiter: (oldValue: string, value: string, options: NumberInputOptions) => boolean;

--- a/dist/components/helpers.d.ts
+++ b/dist/components/helpers.d.ts
@@ -1,4 +1,3 @@
 import { InputManipulator } from './types';
-
 export declare const createChangeEventManipulator: (ref: React.RefObject<HTMLInputElement>, manipulator: InputManipulator, onChange?: React.InputHTMLAttributes<HTMLInputElement>["onChange"]) => (e: React.ChangeEvent<HTMLInputElement>) => void;
 export declare const createBlurEventManipulator: (ref: React.RefObject<HTMLInputElement>, manipulator: InputManipulator, onBlur?: React.InputHTMLAttributes<HTMLInputElement>["onBlur"]) => (e: React.FocusEvent<HTMLInputElement>) => void;

--- a/dist/components/index.d.ts
+++ b/dist/components/index.d.ts
@@ -1,5 +1,4 @@
 import { default as BlocksRangeInput, BlocksRangeInputProps } from './BlocksRangeInput';
 import { default as NumberInput, NumberInputProps } from './NumberInput';
-
 export { NumberInput, BlocksRangeInput };
 export type { BlocksRangeInputProps, NumberInputProps };

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,2 @@
 export * from './components/index'
+export {}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         }
     },
     "engines": {
-        "node": ">=18.13.0 < 21.0.0"
+        "node": ">=20.0.0 < 23.0.0"
     },
     "resolutions": {
         "string-width": "^4",


### PR DESCRIPTION
Fix PR build by allow the new node 22 LTS and remove support for 18/19

> error formatting-inputs@0.1.0: The engine "node" is incompatible with this
> module. Expected version ">=18.13.0 < 21.0.0". Got "22.11.0"
> error Found incompatible module.
